### PR TITLE
Maya Log Connect fix for windows PyCharm

### DIFF
--- a/src/ca/rightsomegoodgames/mayacharm/resources/PythonStrings.java
+++ b/src/ca/rightsomegoodgames/mayacharm/resources/PythonStrings.java
@@ -1,7 +1,7 @@
 package ca.rightsomegoodgames.mayacharm.resources;
 
 public final class PythonStrings {
-    public static final String CONNECT_LOG = "import maya.cmds as cmds; cmds.cmdFileOutput(o=\"{0}\")";
+    public static final String CONNECT_LOG = "import maya.cmds as cmds; cmds.cmdFileOutput(o=r\"{0}\")";
     public static final String EXECFILE = "python (\"execfile (\\\"{0}\\\")\");";
 
     public static final String SETTRACE = "import pydevd; pydevd.settrace(\"localhost\", port=%1$s, suspend=%2$s, stdoutToServer=%3$s, stderrToServer=%3$s)";


### PR DESCRIPTION
getPluginTempPath returns backslashes for path separators in some versions of PyCharm.
Therefore mayaLogPath written by connectMayaLog would be improperly escaped.
This would cause the Maya Log to fail to connect.

Making the template use a raw string should resolve this issue.